### PR TITLE
Add TX cli commands: 1.config tx monitor params, 2.show configuration…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1016,6 +1016,25 @@ def load_minigraph(no_service_restart):
 
 
 #
+# 'tx_monitor' command
+# config tx_monitor Default_PoolingPeriod 60
+# config tx_monitor Default_Threshold 10
+#
+@config.command("tx_monitor")
+@click.argument('param', required=True)
+@click.argument('value', required=True)
+def txmonitor_set(param, value):
+    if param.lower() != 'threshold' and param.lower() != 'pooling_period':
+        click.echo("Please enter valid configurations")
+    else:
+        table_name = "TX_MONITOR"
+        config_db = ConfigDBConnector()
+        config_db.connect()
+        click.echo(param)
+        config_db.set_entry(table_name, param, {"Value":value})
+
+
+#
 # 'hostname' command
 #
 @config.command('hostname')
@@ -2350,6 +2369,7 @@ def unbind(ctx, interface_name):
     for interface_del in interface_dependent:
         config_db.set_entry(table_name, interface_del, None)
     config_db.set_entry(table_name, interface_name, None)
+
 
 
 #


### PR DESCRIPTION
…, 3.show ports tx-state

Signed-off-by: Noy Saban <noysa@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added 2 purposes cli-commands. 
1. Config commands: 
"config tx_monitor pooling_period $NUM" which configure timer interval for tx-monitor
"config tx_monitor threshold $NUM" which configure threshold for tx-monitor

2. Show commands: 
"show tx_monitor tx_config" which present to the user the current  tx-monitor configuration
"show tx_monitor tx_state" which present to the user the current  tx-monitor state for all ports

**- How I did it**

**- How to verify it**
Change configuration with the 'config commands' and the show it with the 'show commands'.
Inject tx-counter values and verify (by 'show commands') the port state reaction to it.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

